### PR TITLE
chore: add maintenance section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ That's all. I've tested this container on multipl linux machines.
 If you will have a troubles with it, please open issue ticket. 
 
 Thanks Felix.
+
+## Maintenance
+
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
## What changed
- Added a `## Maintenance` section to README.
- Added the contribution reference line: `See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.`

## Why
- Makes maintenance expectations explicit and consistent across Dockette repositories.