### PR TITLE
Docs: mark Factorio repository as legacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Project
+
+Dockette Factorio is a legacy Docker/game repository for running the Factorio desktop client through Docker and X11. Treat it as a historical mirror unless maintainers explicitly decide to revive or archive it.
+
+## Repository Status
+
+- The repository contains old Dockerfiles for Factorio `0.12.x`, a base image, a sources image, and the `bin/run` X11 launcher.
+- Current scripts reference the legacy `dockergames/factorio` image namespace.
+- Do not add a Docker Hub pulls badge for `dockette/factorio`; no active `dockette/factorio` image is published for new users.
+- Prefer documentation-only changes over CI rollout changes unless maintainers confirm the image should be actively rebuilt.
+
+## Validation
+
+- Run `git diff --check` after edits.
+- If a Makefile or workflow is introduced later, keep it minimal and verify `make -n build test run`.
+- Keep `CLAUDE.md` exactly `@AGENTS.md`.
+
+## Guidelines
+
+- Preserve the legacy Dockerfiles and launcher behavior unless the task explicitly revives the image.
+- Keep README badges limited to applicable Dockette badges; do not add Slack, Gitter, or Docker pulls badges for this archived/legacy image.
+- Keep the Maintenance section aligned with the standard Dockette wording.
+- Document deprecated or superseded behavior clearly rather than implying current support.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Factorio in Docker
 
-See [dockergames/factorio](https://hub.docker.com/r/dockergames/factorio/) on Docker Hub.
+<p align=center>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+This repository is a historical mirror of the original Dockette Factorio desktop image. It is not actively maintained as a current Dockette image, and no `dockette/factorio` Docker Hub image is published for new deployments.
+
+The maintained image for this lineage lives at [`dockergames/factorio`](https://hub.docker.com/r/dockergames/factorio). The old scripts in this repository still reference that namespace for archive purposes.
 
 ![Factorio in Docker container](https://raw.githubusercontent.com/whaleapps/factorio/master/docs/factorio.png)
 


### PR DESCRIPTION
What changed
- Added Dockette sponsor/support badges without adding a Docker pulls badge for the unpublished dockette/factorio image.
- Documented this repository as a historical mirror and pointed users to the dockergames/factorio image lineage.
- Added repo-local AGENTS.md instructions and CLAUDE.md forwarding to AGENTS.md.

Why
- factorio is a legacy/game repository and is not a good candidate for a fragile CI rollout without an explicit maintenance decision.
- The docs-only baseline makes the repository status clear while preserving the old Dockerfiles and launcher behavior.